### PR TITLE
docs: Replace legacy config format with unified format in all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,20 @@ curl http://localhost:8080/api/users/123
 
 ## Configuration
 
-Create `config.yaml` with endpoint sections:
+Create `config.yaml` with the unified format:
 
 ```yaml
-users:
-  path_pattern: "/api/users/*"
-  body_id_paths: ["/id"]
-  header_id_names: ["X-User-ID", "Authorization"]  # Multiple headers supported
-  return_body: true
+sections:
+  users:
+    path_pattern: "/api/users/*"
+    body_id_paths: ["/id"]
+    header_id_names: ["X-User-ID", "Authorization"]  # Multiple headers supported
+    return_body: true
 
-orders:
-  path_pattern: "/api/orders/*"
-  body_id_paths: ["/order_id"]
-  header_id_names: ["X-Order-ID"]
+  orders:
+    path_pattern: "/api/orders/*"
+    body_id_paths: ["/order_id"]
+    header_id_names: ["X-Order-ID"]
 ```
 
 **➜ [Copy-paste examples](examples/configs/) | [Full config guide](docs/configuration.md)**
@@ -40,13 +41,18 @@ orders:
 Pre-define responses for testing:
 
 ```yaml
+sections:
+  users:
+    path_pattern: "/api/users/*"
+    body_id_paths: ["/id"]
+
 scenarios:
   - uuid: "user-not-found"
     method: "GET"
     path: "/api/users/999"
-    response:
-      status_code: 404
-      body: '{"error": "User not found"}'
+    status_code: 404
+    content_type: "application/json"
+    data: '{"error": "User not found"}'
 ```
 
 **➜ [Scenario examples](docs/scenarios.md)**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,9 +33,9 @@ scenarios:
   - uuid: "user-not-found"
     method: "GET"
     path: "/api/users/999"
-    response:
-      status_code: 404
-      body: '{"error": "User not found"}'
+    status_code: 404
+    content_type: "application/json"
+    data: '{"error": "User not found"}'
 ```
 
 ### 2. Legacy Format (Still Supported)

--- a/helm/unimock/README.md
+++ b/helm/unimock/README.md
@@ -161,11 +161,13 @@ The following table lists the configurable parameters of the Unimock chart and t
 
 config:
   sections:
-    - path: "/api/users/*"
-      id_path: "/id"
+    users:
+      path_pattern: "/api/users/*"
+      body_id_paths: ["/id"]
       return_body: true
-    - path: "/api/products/*"
-      id_path: "/product_id"
+    products:
+      path_pattern: "/api/products/*"
+      body_id_paths: ["/product_id"]
       return_body: true
 
 resources:
@@ -284,8 +286,9 @@ Use structured YAML objects for better validation and IDE support:
 ```yaml
 config:
   sections:
-    - path: "/api/users/*"
-      id_path: "/id"
+    users:
+      path_pattern: "/api/users/*"
+      body_id_paths: ["/id"]
       return_body: true
 
 scenarios:
@@ -296,6 +299,7 @@ scenarios:
         method: "GET"
         path: "/test"
         status_code: 200
+        content_type: "text/plain"
         data: "test response"
 ```
 
@@ -307,8 +311,9 @@ Alternatively, use raw YAML strings:
 config:
   yaml: |
     sections:
-      - path: "/api/users/*"
-        id_path: "/id"
+      users:
+        path_pattern: "/api/users/*"
+        body_id_paths: ["/id"]
 
 scenarios:
   enabled: true
@@ -318,6 +323,7 @@ scenarios:
         method: "GET"
         path: "/test"
         status_code: 200
+        content_type: "text/plain"
         data: "test response"
 ```
 


### PR DESCRIPTION
## Summary
• Updated README.md main configuration examples to use unified format with `sections:` wrapper
• Fixed docs/configuration.md scenario format to use `data` instead of deprecated `response.body` 
• Updated helm/unimock/README.md all configuration examples to use unified format
• Ensures consistency across all documentation with actual implementation and examples/configs/

## Test plan
- [x] Verify all documentation examples use unified format with `sections:` wrapper
- [x] Confirm scenario examples use correct `data` field instead of `response.body`
- [x] Check Helm chart README examples follow unified format
- [x] Run `make check` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)