### PR TITLE
feat: Enable scenarios-only configuration support

### DIFF
--- a/e2e/scenarios_file_test.go
+++ b/e2e/scenarios_file_test.go
@@ -84,12 +84,12 @@ func setupScenarioTestServer(t *testing.T, configFile string) (*http.Server, str
 		ConfigPath: configFile,
 	}
 
-	uniConfig, err := config.LoadFromYAML(configFile)
+	unifiedConfig, err := config.LoadUnifiedFromYAML(configFile)
 	if err != nil {
 		t.Fatalf("Failed to load unified config: %v", err)
 	}
 
-	srv, err := pkg.NewServer(serverConfig, uniConfig)
+	srv, err := pkg.NewServer(serverConfig, unifiedConfig)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}

--- a/e2e/scenarios_file_test.go
+++ b/e2e/scenarios_file_test.go
@@ -84,12 +84,12 @@ func setupScenarioTestServer(t *testing.T, configFile string) (*http.Server, str
 		ConfigPath: configFile,
 	}
 
-	unifiedConfig, err := config.LoadUnifiedFromYAML(configFile)
+	uniConfig, err := config.LoadFromYAML(configFile)
 	if err != nil {
 		t.Fatalf("Failed to load unified config: %v", err)
 	}
 
-	srv, err := pkg.NewServer(serverConfig, unifiedConfig)
+	srv, err := pkg.NewServer(serverConfig, uniConfig)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}

--- a/e2e/scenarios_only_test.go
+++ b/e2e/scenarios_only_test.go
@@ -64,20 +64,18 @@ scenarios:
 	configFile := createTempConfigFile(t, configContent)
 	defer os.Remove(configFile)
 
-	// Create server config pointing to scenarios-only config
+	// Create server config
 	serverConfig := &config.ServerConfig{
-		Port:       "0", // Use random available port
-		LogLevel:   "error",
-		ConfigPath: configFile,
+		Port:     "0", // Use random available port
+		LogLevel: "error",
 	}
 
-	// Create empty UniConfig (no sections)
-	uniConfig := &config.UniConfig{
-		Sections: map[string]config.Section{}, // Empty sections map
-	}
+	// Load unified config from scenarios-only file
+	unifiedConfig, err := config.LoadUnifiedFromYAML(configFile)
+	require.NoError(t, err, "Should load scenarios-only config")
 
 	// This should work - server should start with scenarios-only config
-	server, err := pkg.NewServer(serverConfig, uniConfig)
+	server, err := pkg.NewServer(serverConfig, unifiedConfig)
 	require.NoError(t, err, "Server should start with scenarios-only configuration")
 
 	// Use httptest server instead for reliable testing

--- a/e2e/scenarios_only_test.go
+++ b/e2e/scenarios_only_test.go
@@ -1,0 +1,199 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bmcszk/unimock/pkg"
+	"github.com/bmcszk/unimock/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScenariosOnlyConfiguration(t *testing.T) {
+	// Create temporary config file with only scenarios, no sections
+	configContent := `
+scenarios:
+  - uuid: "test-user-get"
+    method: "GET"
+    path: "/api/users/123"
+    status_code: 200
+    content_type: "application/json"
+    data: |
+      {
+        "id": "123",
+        "name": "Test User",
+        "email": "test@example.com"
+      }
+  
+  - uuid: "test-product-post"
+    method: "POST"
+    path: "/api/products"
+    status_code: 201
+    content_type: "application/json"
+    location: "/api/products/456"
+    data: |
+      {
+        "id": "456",
+        "name": "Test Product",
+        "price": 99.99
+      }
+  
+  - uuid: "test-error-scenario"
+    method: "GET"
+    path: "/api/error"
+    status_code: 500
+    content_type: "application/json"
+    data: |
+      {
+        "error": "Internal server error",
+        "code": "SERVER_ERROR"
+      }
+`
+
+	configFile := createTempConfigFile(t, configContent)
+	defer os.Remove(configFile)
+
+	// Create server config pointing to scenarios-only config
+	serverConfig := &config.ServerConfig{
+		Port:       "0", // Use random available port
+		LogLevel:   "error",
+		ConfigPath: configFile,
+	}
+
+	// Create empty UniConfig (no sections)
+	uniConfig := &config.UniConfig{
+		Sections: map[string]config.Section{}, // Empty sections map
+	}
+
+	// This should work - server should start with scenarios-only config
+	server, err := pkg.NewServer(serverConfig, uniConfig)
+	require.NoError(t, err, "Server should start with scenarios-only configuration")
+
+	// Use httptest server instead for reliable testing
+	testServer := http.Server{
+		Handler: server.Handler,
+	}
+
+	// Start with httptest for reliable address
+	listener, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+
+	testServer.Addr = listener.Addr().String()
+
+	go func() {
+		if err := testServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+			t.Logf("Server error: %v", err)
+		}
+	}()
+
+	// Wait for server to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Get server address
+	baseURL := fmt.Sprintf("http://%s", testServer.Addr)
+
+	// Cleanup
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		testServer.Shutdown(ctx)
+	}()
+
+	// Test scenarios work correctly
+	t.Run("GET scenario returns expected response", func(t *testing.T) {
+		resp, err := http.Get(baseURL + "/api/users/123")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, 200, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		expectedJSON := `{
+  "id": "123",
+  "name": "Test User",
+  "email": "test@example.com"
+}`
+		assert.JSONEq(t, expectedJSON, string(body))
+	})
+
+	t.Run("POST scenario returns expected response with location header", func(t *testing.T) {
+		resp, err := http.Post(baseURL+"/api/products", "application/json",
+			strings.NewReader(`{"name": "Test Product", "price": 99.99}`))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, 201, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+		assert.Equal(t, "/api/products/456", resp.Header.Get("Location"))
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		expectedJSON := `{
+  "id": "456",
+  "name": "Test Product",
+  "price": 99.99
+}`
+		assert.JSONEq(t, expectedJSON, string(body))
+	})
+
+	t.Run("Error scenario returns expected error response", func(t *testing.T) {
+		resp, err := http.Get(baseURL + "/api/error")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, 500, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		expectedJSON := `{
+  "error": "Internal server error",
+  "code": "SERVER_ERROR"
+}`
+		assert.JSONEq(t, expectedJSON, string(body))
+	})
+
+	t.Run("Non-scenario path returns 404 (no sections configured)", func(t *testing.T) {
+		resp, err := http.Get(baseURL + "/api/unknown")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Should return 404 since no sections are configured to handle this path
+		assert.Equal(t, 404, resp.StatusCode)
+	})
+
+	t.Run("Health endpoint still works", func(t *testing.T) {
+		resp, err := http.Get(baseURL + "/_uni/health")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, 200, resp.StatusCode)
+	})
+}
+
+func createTempConfigFile(t *testing.T, content string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	err := os.WriteFile(configFile, []byte(content), 0644)
+	require.NoError(t, err)
+
+	return configFile
+}

--- a/e2e/scenarios_only_test.go
+++ b/e2e/scenarios_only_test.go
@@ -71,11 +71,11 @@ scenarios:
 	}
 
 	// Load unified config from scenarios-only file
-	unifiedConfig, err := config.LoadUnifiedFromYAML(configFile)
+	uniConfig, err := config.LoadFromYAML(configFile)
 	require.NoError(t, err, "Should load scenarios-only config")
 
 	// This should work - server should start with scenarios-only config
-	server, err := pkg.NewServer(serverConfig, unifiedConfig)
+	server, err := pkg.NewServer(serverConfig, uniConfig)
 	require.NoError(t, err, "Server should start with scenarios-only configuration")
 
 	// Use httptest server instead for reliable testing

--- a/examples/library/main.go
+++ b/examples/library/main.go
@@ -24,8 +24,8 @@ func main() {
 
 	logger.Info("Starting Unimock with in-code configuration")
 
-	// Step 1: Create a uni configuration with API endpoints
-	uniConfig := &config.UniConfig{
+	// Step 1: Create a unified configuration with API endpoints
+	unifiedConfig := &config.UnifiedConfig{
 		Sections: map[string]config.Section{
 			"api": {
 				// Match paths like /api/123
@@ -44,6 +44,7 @@ func main() {
 				HeaderIDNames: []string{"X-User-ID"},
 			},
 		},
+		Scenarios: []config.ScenarioConfig{}, // Empty scenarios for this example
 	}
 
 	// Step 2: Create server configuration
@@ -55,7 +56,7 @@ func main() {
 
 	// Step 3: Initialize the server
 	logger.Info("Creating server with configuration")
-	srv, err := pkg.NewServer(serverConfig, uniConfig)
+	srv, err := pkg.NewServer(serverConfig, unifiedConfig)
 
 	if err != nil {
 		log.Fatalf("Failed to start server: %v", err)

--- a/examples/library/main.go
+++ b/examples/library/main.go
@@ -25,7 +25,7 @@ func main() {
 	logger.Info("Starting Unimock with in-code configuration")
 
 	// Step 1: Create a unified configuration with API endpoints
-	unifiedConfig := &config.UnifiedConfig{
+	uniConfig := &config.UniConfig{
 		Sections: map[string]config.Section{
 			"api": {
 				// Match paths like /api/123
@@ -56,7 +56,7 @@ func main() {
 
 	// Step 3: Initialize the server
 	logger.Info("Creating server with configuration")
-	srv, err := pkg.NewServer(serverConfig, unifiedConfig)
+	srv, err := pkg.NewServer(serverConfig, uniConfig)
 
 	if err != nil {
 		log.Fatalf("Failed to start server: %v", err)

--- a/main.go
+++ b/main.go
@@ -35,15 +35,15 @@ func main() {
 		"config_path", serverConfig.ConfigPath,
 		"log_level", serverConfig.LogLevel)
 
-	// Load mock configuration from file
-	uniConfig, err := config.LoadFromYAML(serverConfig.ConfigPath)
+	// Load unified configuration from file
+	unifiedConfig, err := config.LoadUnifiedFromYAML(serverConfig.ConfigPath)
 	if err != nil {
 		logger.Error("failed to load configuration", "error", err)
 		panic(err)
 	}
 
 	// Start the server
-	srv, err := pkg.NewServer(serverConfig, uniConfig)
+	srv, err := pkg.NewServer(serverConfig, unifiedConfig)
 	if err != nil {
 		logger.Error("failed to initialize server", "error", err)
 		panic(err)

--- a/main.go
+++ b/main.go
@@ -36,14 +36,14 @@ func main() {
 		"log_level", serverConfig.LogLevel)
 
 	// Load unified configuration from file
-	unifiedConfig, err := config.LoadUnifiedFromYAML(serverConfig.ConfigPath)
+	uniConfig, err := config.LoadFromYAML(serverConfig.ConfigPath)
 	if err != nil {
 		logger.Error("failed to load configuration", "error", err)
 		panic(err)
 	}
 
 	// Start the server
-	srv, err := pkg.NewServer(serverConfig, unifiedConfig)
+	srv, err := pkg.NewServer(serverConfig, uniConfig)
 	if err != nil {
 		logger.Error("failed to initialize server", "error", err)
 		panic(err)

--- a/pkg/config/uni_config.go
+++ b/pkg/config/uni_config.go
@@ -31,6 +31,9 @@ type UniConfig struct {
 	// The map keys are section names (usually API resource names like "users" or "orders")
 	// and the values are Section structs defining how to handle requests to those endpoints.
 	Sections map[string]Section `yaml:",inline" json:"sections"`
+
+	// Scenarios contains predefined responses that override normal mock behavior
+	Scenarios []ScenarioConfig `yaml:"scenarios,omitempty" json:"scenarios,omitempty"`
 }
 
 // UnifiedConfig represents the unified configuration format that includes
@@ -185,7 +188,8 @@ type Section struct {
 // NewUniConfig creates an empty UniConfig with an initialized Sections map
 func NewUniConfig() *UniConfig {
 	return &UniConfig{
-		Sections: make(map[string]Section),
+		Sections:  make(map[string]Section),
+		Scenarios: []ScenarioConfig{},
 	}
 }
 
@@ -203,10 +207,13 @@ func LoadFromYAML(path string) (*UniConfig, error) {
 	decoder.KnownFields(false) // Disable strict mode for format detection
 
 	unifiedErr := decoder.Decode(unified)
-	if unifiedErr == nil && unified.Sections != nil && len(unified.Sections) > 0 {
+	if unifiedErr == nil && (len(unified.Sections) > 0 || len(unified.Scenarios) > 0) {
 		// Successfully parsed as unified format
 		unified.Normalize()
-		config := &UniConfig{Sections: unified.Sections}
+		config := &UniConfig{
+			Sections:  unified.Sections,
+			Scenarios: unified.Scenarios,
+		}
 		return config, nil
 	}
 

--- a/pkg/server_test.go
+++ b/pkg/server_test.go
@@ -36,17 +36,17 @@ scenarios:
 		}
 
 		// Load unified config from file - should work with scenarios only
-		unifiedConfig, err := config.LoadUnifiedFromYAML(configFile)
+		uniConfig, err := config.LoadFromYAML(configFile)
 		require.NoError(t, err)
 
-		server, err := pkg.NewServer(serverConfig, unifiedConfig)
+		server, err := pkg.NewServer(serverConfig, uniConfig)
 		require.NoError(t, err, "Should create server with empty sections when scenarios exist")
 		require.NotNil(t, server)
 	})
 
 	t.Run("should reject completely empty config (no sections, no scenarios)", func(t *testing.T) {
-		// Create empty unified config
-		unifiedConfig := &config.UnifiedConfig{
+		// Create empty uni config
+		uniConfig := &config.UniConfig{
 			Sections:  map[string]config.Section{},
 			Scenarios: []config.ScenarioConfig{},
 		}
@@ -56,7 +56,7 @@ scenarios:
 			LogLevel: "error",
 		}
 
-		server, err := pkg.NewServer(serverConfig, unifiedConfig)
+		server, err := pkg.NewServer(serverConfig, uniConfig)
 		require.Error(t, err, "Should reject config with no sections and no scenarios")
 		require.Nil(t, server)
 
@@ -71,7 +71,7 @@ scenarios:
 			LogLevel: "error",
 		}
 
-		unifiedConfig := &config.UnifiedConfig{
+		uniConfig := &config.UniConfig{
 			Sections: map[string]config.Section{
 				"users": {
 					PathPattern: "/users/*",
@@ -81,7 +81,7 @@ scenarios:
 			Scenarios: []config.ScenarioConfig{},
 		}
 
-		server, err := pkg.NewServer(serverConfig, unifiedConfig)
+		server, err := pkg.NewServer(serverConfig, uniConfig)
 		require.NoError(t, err, "Should accept config with sections")
 		require.NotNil(t, server)
 	})
@@ -92,14 +92,14 @@ scenarios:
 			LogLevel: "error",
 		}
 
-		// Nil unified config should be rejected
+		// Nil uni config should be rejected
 		server, err := pkg.NewServer(serverConfig, nil)
-		require.Error(t, err, "Should reject nil unified config")
+		require.Error(t, err, "Should reject nil uni config")
 		require.Nil(t, server)
 
 		var configErr *pkg.ConfigError
 		require.ErrorAs(t, err, &configErr)
-		assert.Contains(t, configErr.Message, "unified configuration is nil")
+		assert.Contains(t, configErr.Message, "uni configuration is nil")
 	})
 }
 
@@ -128,10 +128,10 @@ scenarios:
 		}
 
 		// Load unified config from file
-		unifiedConfig, err := config.LoadUnifiedFromYAML(configFile)
+		uniConfig, err := config.LoadFromYAML(configFile)
 		require.NoError(t, err)
 
-		server, err := pkg.NewServer(serverConfig, unifiedConfig)
+		server, err := pkg.NewServer(serverConfig, uniConfig)
 		require.NoError(t, err)
 
 		// Start test server
@@ -183,10 +183,10 @@ scenarios:
 		}
 
 		// Load unified config from file
-		unifiedConfig, err := config.LoadUnifiedFromYAML(configFile)
+		uniConfig, err := config.LoadFromYAML(configFile)
 		require.NoError(t, err)
 
-		server, err := pkg.NewServer(serverConfig, unifiedConfig)
+		server, err := pkg.NewServer(serverConfig, uniConfig)
 		require.NoError(t, err)
 
 		testServer := httptest.NewServer(server.Handler)

--- a/pkg/server_test.go
+++ b/pkg/server_test.go
@@ -1,0 +1,226 @@
+package pkg_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bmcszk/unimock/pkg"
+	"github.com/bmcszk/unimock/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServer_ScenariosOnly(t *testing.T) {
+	t.Run("should create server with empty sections and scenarios from file", func(t *testing.T) {
+		// Create temporary config file with only scenarios
+		configContent := `
+scenarios:
+  - uuid: "test-scenario"
+    method: "GET"
+    path: "/test"
+    status_code: 200
+    content_type: "application/json"
+    data: '{"message": "test response"}'
+`
+		configFile := createTempConfigFile(t, configContent)
+		defer os.Remove(configFile)
+
+		serverConfig := &config.ServerConfig{
+			Port:       "0",
+			LogLevel:   "error",
+			ConfigPath: configFile,
+		}
+
+		// Empty sections should be allowed when scenarios exist
+		uniConfig := &config.UniConfig{
+			Sections: map[string]config.Section{},
+		}
+
+		server, err := pkg.NewServer(serverConfig, uniConfig)
+		require.NoError(t, err, "Should create server with empty sections when scenarios exist")
+		require.NotNil(t, server)
+	})
+
+	t.Run("should reject completely empty config (no sections, no scenarios)", func(t *testing.T) {
+		// Create empty config file
+		configFile := createTempConfigFile(t, "")
+		defer os.Remove(configFile)
+
+		serverConfig := &config.ServerConfig{
+			Port:       "0",
+			LogLevel:   "error",
+			ConfigPath: configFile,
+		}
+
+		uniConfig := &config.UniConfig{
+			Sections: map[string]config.Section{},
+		}
+
+		server, err := pkg.NewServer(serverConfig, uniConfig)
+		require.Error(t, err, "Should reject config with no sections and no scenarios")
+		require.Nil(t, server)
+
+		var configErr *pkg.ConfigError
+		require.ErrorAs(t, err, &configErr)
+		assert.Contains(t, configErr.Message, "no sections or scenarios defined")
+	})
+
+	t.Run("should accept config with sections but no scenarios", func(t *testing.T) {
+		serverConfig := &config.ServerConfig{
+			Port:     "0",
+			LogLevel: "error",
+		}
+
+		uniConfig := &config.UniConfig{
+			Sections: map[string]config.Section{
+				"users": {
+					PathPattern: "/users/*",
+					BodyIDPaths: []string{"/id"},
+				},
+			},
+		}
+
+		server, err := pkg.NewServer(serverConfig, uniConfig)
+		require.NoError(t, err, "Should accept config with sections")
+		require.NotNil(t, server)
+	})
+
+	t.Run("should handle missing config file gracefully", func(t *testing.T) {
+		serverConfig := &config.ServerConfig{
+			Port:       "0",
+			LogLevel:   "error",
+			ConfigPath: "/nonexistent/file.yaml",
+		}
+
+		uniConfig := &config.UniConfig{
+			Sections: map[string]config.Section{},
+		}
+
+		server, err := pkg.NewServer(serverConfig, uniConfig)
+		require.Error(t, err, "Should reject config with no sections when config file is missing")
+		require.Nil(t, server)
+	})
+}
+
+func TestScenariosOnlyIntegration(t *testing.T) {
+	t.Run("scenarios work without sections", func(t *testing.T) {
+		// Create config with only scenarios
+		configContent := `
+scenarios:
+  - uuid: "integration-test"
+    method: "GET"
+    path: "/api/test/123"
+    status_code: 200
+    content_type: "application/json"
+    data: |
+      {
+        "id": "123",
+        "message": "Integration test response"
+      }
+`
+		configFile := createTempConfigFile(t, configContent)
+		defer os.Remove(configFile)
+
+		serverConfig := &config.ServerConfig{
+			Port:       "0",
+			LogLevel:   "error",
+			ConfigPath: configFile,
+		}
+
+		uniConfig := &config.UniConfig{
+			Sections: map[string]config.Section{},
+		}
+
+		server, err := pkg.NewServer(serverConfig, uniConfig)
+		require.NoError(t, err)
+
+		// Start test server
+		testServer := httptest.NewServer(server.Handler)
+		defer testServer.Close()
+
+		// Test the scenario endpoint
+		resp, err := http.Get(testServer.URL + "/api/test/123")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, 200, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		expectedJSON := `{
+  "id": "123",
+  "message": "Integration test response"
+}`
+		assert.JSONEq(t, expectedJSON, string(body))
+
+		// Test non-scenario endpoint returns 404
+		resp2, err := http.Get(testServer.URL + "/api/unknown")
+		require.NoError(t, err)
+		defer resp2.Body.Close()
+
+		assert.Equal(t, 404, resp2.StatusCode)
+	})
+
+	t.Run("POST scenario works without sections", func(t *testing.T) {
+		configContent := `
+scenarios:
+  - uuid: "post-test"
+    method: "POST"
+    path: "/api/create"
+    status_code: 201
+    content_type: "application/json"
+    location: "/api/created/456"
+    data: '{"id": "456", "status": "created"}'
+`
+		configFile := createTempConfigFile(t, configContent)
+		defer os.Remove(configFile)
+
+		serverConfig := &config.ServerConfig{
+			Port:       "0",
+			LogLevel:   "error",
+			ConfigPath: configFile,
+		}
+
+		uniConfig := &config.UniConfig{
+			Sections: map[string]config.Section{},
+		}
+
+		server, err := pkg.NewServer(serverConfig, uniConfig)
+		require.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Handler)
+		defer testServer.Close()
+
+		// Test POST scenario
+		resp, err := http.Post(testServer.URL+"/api/create", "application/json",
+			strings.NewReader(`{"data": "test"}`))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, 201, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+		assert.Equal(t, "/api/created/456", resp.Header.Get("Location"))
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"id": "456", "status": "created"}`, string(body))
+	})
+}
+
+func createTempConfigFile(t *testing.T, content string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	err := os.WriteFile(configFile, []byte(content), 0644)
+	require.NoError(t, err)
+
+	return configFile
+}


### PR DESCRIPTION
## Summary
- Enables Unimock to start with empty sections when scenarios exist in unified config
- Adds validation to accept configurations with scenarios-only or sections-only
- Maintains backward compatibility with existing section-based configurations

## Changes
- Modified `pkg/server.go` validation logic to allow scenarios-only configurations
- Added comprehensive E2E tests in `e2e/scenarios_only_test.go`
- Added unit tests in `pkg/server_test.go` covering validation scenarios
- Extracted validation functions for better code organization and reduced complexity

## Test Coverage
- E2E test verifies GET, POST, error scenarios work without sections
- Unit tests cover validation edge cases and integration scenarios
- All existing tests continue to pass ensuring no regressions

## Technical Details
- Server logs "running in scenarios-only mode" when no sections configured
- Scenarios are loaded from unified config file during server initialization
- Non-scenario paths return 404 when no sections are configured (expected behavior)

🤖 Generated with [Claude Code](https://claude.ai/code)